### PR TITLE
Setup Vagrant-based development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,14 @@
+# Ansible
+deployment/ansible/roles/azavea.*
+*.retry
+
+# Vagrant
+.vagrant
+
+# Jekyll
 _site
 .sass-cache
 .jekyll-metadata
+
+# OSX
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ ./scripts/update
 
 ## URLS
 
-The Vagrant configuration creates a host-only private network between the virtual machine host and the Vagrant virtual machine. In order to access the content served by Jekyll, and the LiveReload endpoint, use the following links:
+In order to access the content served by Jekyll, and the LiveReload endpoint, use the following links:
 
 | Service    | URL                                                    |
 |------------|--------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A design system for Azavea that contains visual assets (logos, color palettes, l
 ## How it works
 Azavea’s design system is built using [Jekyll](https://jekyllrb.com/), a static site generator, and [Style Guide Guide](https://github.com/bradfrost/style-guide-guide), a style guide boilerplate. The SCSS follows rules set in Brad Frost's article [CSS Architecture for Design Systems.](http://bradfrost.com/blog/post/css-architecture-for-design-systems/)
 
+Jekyll uses a plugin called [Hawkins](https://github.com/awood/hawkins) (specified in the `Gemfile`) that integrates with [LiveReload](http://livereload.com) to watch for changes and rebuild static files. 
+
 ## Requirements
 - Vagrant 2.0+
 - VirtualBox 5.1+
@@ -23,7 +25,7 @@ $ vagrant ssh
 $ ./scripts/server
 ```
 
-In order to build Jekyll's static website output, use:
+If `server` isn't running, or to trigger a build of Jekyll's static website output, use:
 
 ```bash
 $ ./scripts/update
@@ -35,4 +37,4 @@ The Vagrant configuration creates a host-only private network between the virtua
 
 | Service    | URL                                                    |
 |------------|--------------------------------------------------------|
-| Jekyll     | [`http://192.168.50.4:4000`](http://192.168.50.4:4000) |
+| Jekyll     | [`http://localhost:4000`](http://localhost:4000) |

--- a/README.md
+++ b/README.md
@@ -4,9 +4,35 @@ A design system for Azavea that contains visual assets (logos, color palettes, l
 ## How it works
 Azavea’s design system is built using [Jekyll](https://jekyllrb.com/), a static site generator, and [Style Guide Guide](https://github.com/bradfrost/style-guide-guide), a style guide boilerplate. The SCSS follows rules set in Brad Frost's article [CSS Architecture for Design Systems.](http://bradfrost.com/blog/post/css-architecture-for-design-systems/)
 
-## Getting Started
-1. Download or clone the files from the [repository on Github](https://github.com/azavea/azavea-design-system).
-2. In the command line, navigate to the root of the project and run 
-```jekyll serve```
-3. This will build and serve the app on port `4000` in your browser.
+## Requirements
+- Vagrant 2.0+
+- VirtualBox 5.1+
 
+## Getting Started
+
+From your workstation, execute the following command to bring up a Vagrant virtual machine with all of the necessary dependencies installed:
+
+```bash
+$ ./scripts/setup
+```
+
+Next, login to the Vagrant virtual machine and launch the Jekyll services:
+
+```bash
+$ vagrant ssh
+$ ./scripts/server
+```
+
+In order to build Jekyll's static website output, use:
+
+```bash
+$ ./scripts/update
+```
+
+## URLS
+
+The Vagrant configuration creates a host-only private network between the virtual machine host and the Vagrant virtual machine. In order to access the content served by Jekyll, and the LiveReload endpoint, use the following links:
+
+| Service    | URL                                                    |
+|------------|--------------------------------------------------------|
+| Jekyll     | [`http://192.168.50.4:4000`](http://192.168.50.4:4000) |

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,10 @@ Vagrant.configure("2") do |config|
 
   # Jekyll 
   config.vm.network :forwarded_port, guest: 4000, host: 4000
+
+  # LiveReload
+  config.vm.network :forwarded_port, guest: 35729, host: 35729
+
   
   config.vm.provider "virtualbox" do |vb|
     vb.gui = false

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,36 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+ANSIBLE_VERSION = "2.4.*"
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.synced_folder "./", "/vagrant"
+  config.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
+
+  config.vm.network "private_network", ip: "192.168.50.4"
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.gui = false
+    vb.memory = 1024
+  end
+
+  config.vm.provision "shell" do |s|
+    s.inline = <<-SHELL
+    if ! grep -q "cd /vagrant" "/home/vagrant/.bashrc"; then
+      echo "cd /vagrant" >> "/home/vagrant/.bashrc"
+    fi
+    SHELL
+  end
+
+  config.vm.provision "ansible_local" do |ansible|
+    ansible.compatibility_mode = "2.0"
+    ansible.install = true
+    ansible.install_mode = "pip_args_only"
+    ansible.pip_args = "ansible==#{ANSIBLE_VERSION}"
+    ansible.playbook = "deployment/ansible/branding-guide.yml"
+    ansible.galaxy_role_file = "deployment/ansible/roles.yml"
+    ansible.galaxy_roles_path = "deployment/ansible/roles"
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,8 +9,9 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder "./", "/vagrant"
   config.vm.synced_folder "~/.aws", "/home/vagrant/.aws"
 
-  config.vm.network "private_network", ip: "192.168.50.4"
-
+  # Jekyll 
+  config.vm.network :forwarded_port, guest: 4000, host: 4000
+  
   config.vm.provider "virtualbox" do |vb|
     vb.gui = false
     vb.memory = 1024

--- a/deployment/ansible/branding-guide.yml
+++ b/deployment/ansible/branding-guide.yml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  become: True
+
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes cache_valid_time=3600
+
+  roles:
+    - role: "azavea.python-security"
+      when: ansible_python_version | version_compare('2.7.9', '<')
+    - role: "branding-guide.docker"

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,0 +1,5 @@
+---
+docker_version: "17.*"
+docker_compose_version: "1.16.*"
+docker_users:
+  - "vagrant"

--- a/deployment/ansible/group_vars/all
+++ b/deployment/ansible/group_vars/all
@@ -1,5 +1,5 @@
 ---
-docker_version: "17.*"
-docker_compose_version: "1.16.*"
+docker_version: "18.*"
+docker_compose_version: "1.21.*"
 docker_users:
   - "vagrant"

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,0 +1,9 @@
+---
+- src: azavea.python-security
+  version: 0.1.0
+
+- src: azavea.pip
+  version: 1.0.0
+
+- src: azavea.docker
+  version: 4.0.0

--- a/deployment/ansible/roles/branding-guide.docker/meta/main.yml
+++ b/deployment/ansible/roles/branding-guide.docker/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - { role: azavea.pip }
+  - { role: azavea.docker }

--- a/deployment/ansible/roles/branding-guide.docker/tasks/main.yml
+++ b/deployment/ansible/roles/branding-guide.docker/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Install Docker Compose
+  pip: name="docker-compose" version="{{ docker_compose_version }}"
+
+- name: Add Ansible user to Docker group
+  user: name="{{ item }}"
+        groups=docker
+        append=yes
+  with_items: "{{ docker_users }}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,9 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./:/usr/src/app
-    network_mode: host
     environment:
       - JEKYLL_ENV=development
       - LANG=C.UTF-8
-    command: liveserve --force_polling --host 192.168.50.4
+    command: liveserve --force_polling --host 0.0.0.0
+    ports:
+            - '4000:4000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,5 @@ services:
       - LANG=C.UTF-8
     command: liveserve --force_polling --host 0.0.0.0
     ports:
-            - '4000:4000'
+        - '4000:4000'
+        - '35729:35729'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,8 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./:/usr/src/app
-    ports:
-      - "4000:4000"
-      - "35729:35729"
+    network_mode: host
     environment:
       - JEKYLL_ENV=development
       - LANG=C.UTF-8
-    command: liveserve --host 0.0.0.0
+    command: liveserve --force_polling --host 192.168.50.4

--- a/scripts/console
+++ b/scripts/console
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${BRANDING_GUIDE_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Login to the jekyll container.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+      docker-compose run --rm --entrypoint /bin/bash jekyll
+    fi
+fi

--- a/scripts/server
+++ b/scripts/server
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${BRANDING_GUIDE_DEBUG}" ]]; then
+    set -x
+fi
+
+DIR="$(dirname "$0")"
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Start and stop Jekyll server.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+      docker-compose up
+    fi
+fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${BRANDING_GUIDE_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Attempts to setup the project's development environment.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        vagrant up --provision
+        rm -rf deployment/ansible/roles/azavea.*
+    fi
+fi

--- a/scripts/update
+++ b/scripts/update
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${BRANDING_GUIDE_DEBUG}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+"Usage: $(basename "$0")
+Build the Jekyll container image.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        docker-compose build
+
+        docker-compose run --rm jekyll build
+    fi
+fi


### PR DESCRIPTION
## Overview

Adds a Vagrant-based development environment and updates documentation.

Fixes #58 

### Notes

Other Jekyll-based websites in our organization establish a private network in `Vagrantfile` and use the host network in `docker-compose.yml`. I talked with @tnation14 about this and couldn't see any advantage vs just forwarding a port. 

All of our Jekyll-based websites bind to the same IP and port (`192.168.50.4:4000`). If people are running multiple development environments at once, this practice won't mitigate collisions. 

Additionally, `update` and `console` will fail if `server` is running.

e.g.

```
ERROR: Cannot create container for service jekyll: conflicting options: host type networking can't be used with links. This would result in undefined behavior
```

## Testing Instructions
```bash
$ ./scripts/setup
$ vagrant ssh
$ ./scripts/server
```
Visit [localhost:4000](http://localhost:4000).