### PR TITLE
Update development environment to Ubuntu 16.04

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 ANSIBLE_VERSION = "2.4.*"
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "bento/ubuntu-16.04"
 
   config.vm.synced_folder "./", "/vagrant"
 

--- a/deployment/ansible/branding-guide.yml
+++ b/deployment/ansible/branding-guide.yml
@@ -7,6 +7,4 @@
       apt: update_cache=yes cache_valid_time=3600
 
   roles:
-    - role: "azavea.python-security"
-      when: ansible_python_version | version_compare('2.7.9', '<')
     - role: "branding-guide.docker"

--- a/deployment/ansible/roles.yml
+++ b/deployment/ansible/roles.yml
@@ -1,7 +1,4 @@
 ---
-- src: azavea.python-security
-  version: 0.1.0
-
 - src: azavea.pip
   version: 1.0.0
 


### PR DESCRIPTION
## Overview

This updates the base Python version beyond Python 2.6.9, which contains support for SNI (now necessary for HTTPS interactions with Ansible Galaxy).

Also, removes the now unnecessary `python-security` role.

Fixes https://github.com/azavea/azavea-branding-guide/issues/77

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

Destory your existing development environment with `vagrant destroy -f`. Then, bring it back up with `setup` and ensure that it comes up as expected.
