### PR TITLE
Add vagrant reload to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ $ ./scripts/setup
 
 Next, login to the Vagrant virtual machine and launch the Jekyll services:
 
+[You may need to `vagrant reload` to properly display fonts and images.]
+
 ```bash
 $ vagrant ssh
 $ ./scripts/server


### PR DESCRIPTION
## Overview

Fonts and images do not necessarily display after provisioning the VM.

This adds reference to `vagrant reload` in the README.
