### PR TITLE
Bug/al/firefox scroll and typo

### DIFF
--- a/_pages/design/logo.md
+++ b/_pages/design/logo.md
@@ -91,7 +91,7 @@ Neither the Azavea logo nor any of its parts may be augmented or altered in any 
 
 - ![Full-color Azavea logo overtop of an image](../images/logo-donts/image.png)
   <span class="c-list--explanation">
-    Don’t overlay the full-color logo onto an image. Please refer to [Photography](/design/photography.html) for more information.
+    Don’t overlay the full-color logo onto an image. 
   </span>
 
 - ![Full-color Azavea logo overtop of an image](../images/logo-donts/low-contrast.svg)

--- a/_sass/layout/_layout.scss
+++ b/_sass/layout/_layout.scss
@@ -33,6 +33,10 @@
  * Main section
  * 1) The main section is the primary content container
  */
+.l-page-layout {
+  min-height: 0; // For Firefox bug
+}
+
  .l-page-layout--two-column-fixed {
     display: flex;
     flex: 1;

--- a/_sass/pages/_home.scss
+++ b/_sass/pages/_home.scss
@@ -36,6 +36,8 @@
   }
 
   .u-margin-bottom-double {
+    padding: 0 0 $pad-spacious;
+
     @media all and (min-width: $bp-small-3) {
       padding: 0 $pad-spacious;
     }


### PR DESCRIPTION
## Overview
This PR fixes a couple of bugs that were noticed upon launch of the site:
- Firefox pages weren't scrolling
- The Logos page had a link that was broken (we had removed that page in an earlier commit)

## Demo
Android + Firefox
![android-firefox-scrolling](https://user-images.githubusercontent.com/5672295/44359739-bf7ccc00-a486-11e8-9fb9-6c6e3ad113c2.gif)


## Testing Instructions
* In Firefox...
* `git pull`
* Enter the guide (the landing page always scrolled properly)
* Go to a page that has content below the fold (Design > Logos is a good bet)
* Attempt to scroll.
* Now look at the "don't" that talks about overlaying our logo overtop of photography. Confirm that there is no link to a "Photography" page.

Closes #97, closes #96 
