### PR TITLE
Add Attribution page

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -48,6 +48,9 @@
   - title: "Email signature"
     href: "/communication/email-signature.html"
     group: "Communication"
+  - title: "Attribution"
+    href: "/communication/attribution.html"
+    group: "Communication"
 ########################
 # DESIGN
 ########################

--- a/_pages/communication/attribution.md
+++ b/_pages/communication/attribution.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: Attribution
+group: communication
+permalink: /communication/attribution.html
+description: Copy suggestions for referencing the company on projects or products.
+
+---
+## Crediting our work
+This copy offers a starting point for writing attribution on our applications and websites. The text options may need to be modified to fit the specific project. Attribution typically is included in the footer area of a product or website.
+
+### Short form
+
+{% include copy-paste.html
+  description = "Software and Design by Azavea."
+%}
+
+### Long form
+
+{% include copy-paste.html
+  description = "Software and design by Azavea: advancing the state of the art in geospatial technology and applying it for civic, social, and environmental impact."
+%}
+
+### Our own products
+
+{% include copy-paste.html
+  description = "© 2016-2018 Azavea Inc., using technology to inform research for civic and social impact. All rights reserved."
+%}
+
+
+## Terms and conditions
+
+We link to the [Terms of Use](https://www.azavea.com/terms-of-use/) and [Privacy Policy](https://www.azavea.com/privacy-policy/) hosted on the Azavea marketing for all products and projects that require these document types.

--- a/_posts/2018-08-28-added-attribution.md
+++ b/_posts/2018-08-28-added-attribution.md
@@ -1,0 +1,14 @@
+---
+layout: post
+title:  "Added Attribution"
+date:   2018-08-28 04:44:44 -0400
+categories: update
+---
+
+This release adds a page for Attribution to offer suggestions for crediting our work on project websites or applications.
+
+## What is in this release
+An Attribution page in the Communication section including:
+
+- Example text for crediting our work
+- Links to Terms of Use and Privacy Policy documents


### PR DESCRIPTION
## Overview

Adds sample text for crediting Azavea work on project websites and applications.

## Testing Instructions

* git pull
* enter Guide
* check sidebar nav for Attribution page in Communications section and review page
* review Release History at bottom of sidebar nav

Closes #60 
