### PR TITLE
Fix incorrect link for Raster Vision download

### DIFF
--- a/_pages/identity/open-source.md
+++ b/_pages/identity/open-source.md
@@ -31,7 +31,7 @@ Azavea develops and maintains several open source tools and libraries as long-te
   alt =  "RasterVision"
   style = "inverted"
 %}
-<a href="/downloads/geotrellis.zip" class="c-btn c-btn--small" download>Download assets</a>
+<a href="/downloads/raster-vision.zip" class="c-btn c-btn--small" download>Download assets</a>
 
 ### Tagline
 {% include copy-paste.html


### PR DESCRIPTION
## Overview
The Raster Vision download was actually downloading GeoTrellis's logos. This has been updated, and I checked other links to make sure it wasn't happening anywhere else.

## Testing Instructions
* `git pull`
* Go to Company > Open source
* Locate Raster Vision's download button, click Download
* You should get Raster Vision's zip file

Closes #114
