### PR TITLE
Add newsletter subscribe text to email signature page

### DIFF
--- a/_pages/communication/email-signature.md
+++ b/_pages/communication/email-signature.md
@@ -32,6 +32,12 @@ description: Create your Azavea email signature.
 {% endcapture %}
 {% assign join_text = join_text | markdownify %}
 
+<!-- Subscribe to newsletter text -->
+{% capture subscribe_text %}
+  [Subscribe to our newsletter](https://www.azavea.com/newsletter) to learn about more positive applications of geospatial data and technology.
+{% endcapture %}
+{% assign subscribe_text = subscribe_text | markdownify %}
+
 <!-- Full email signature text -->
 {% capture full_text %}
   First Name Last Name, Title  
@@ -69,11 +75,15 @@ Add this text below the links in your email signature to help the people you’r
   description = optional_text
 %}
 
-Include “B Corporation” as a link to our company profile on the B Corporation website.
+Include “B Corporation” as a link to our company profile on the B Corporation website. You can also append “Join us.” as a link to the Azavea jobs website to help contacts find our open positions:
 
-You can also append “Join us.” as a link to the Azavea jobs website to help contacts find our open positions:
 {% include copy-paste.html
   description = join_text
+%}
+
+Alternatively, add a link to our newsletter:
+{% include copy-paste.html
+  description = subscribe_text
 %}
 
 ### Full email signature sample with optional text

--- a/_pages/communication/email-signature.md
+++ b/_pages/communication/email-signature.md
@@ -81,7 +81,7 @@ Include “B Corporation” as a link to our company profile on the B Corporatio
   description = join_text
 %}
 
-Alternatively, add a link to our newsletter:
+Alternatively, add a link to our newsletter sign-up:
 {% include copy-paste.html
   description = subscribe_text
 %}

--- a/_posts/2020-10-14-add-subscribe-option-to-email-signatures.md
+++ b/_posts/2020-10-14-add-subscribe-option-to-email-signatures.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title:  "Update to Email Signatures"
+date:   2020-08-06
+categories: update
+---
+
+## Added option
+A new option has been added to the [Email Signatures](/communication/email-signature.html) page, under [Optional Text.](/communication/email-signature.html#optional-text) This one adds copy and link for subscribing to Azavea's newsletter. 


### PR DESCRIPTION
## Overview
Adds a new copy/paste block for email signatures to include subscribing to our newsletter.

### Demo

<img width="1468" alt="Screen Shot 2020-10-14 at 3 05 02 PM" src="https://user-images.githubusercontent.com/5672295/96000329-ad143800-0e2e-11eb-82a5-c1b0acdd4e22.png">

<img width="1792" alt="Screen Shot 2020-10-14 at 3 14 40 PM" src="https://user-images.githubusercontent.com/5672295/96001517-04ff6e80-0e30-11eb-85fc-fd8795e07408.png">


### Notes

N/A


## Testing Instructions
N/A

Connects https://github.com/azavea/azavea-marketing/issues/16
